### PR TITLE
Make the SU solution switchable

### DIFF
--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -16,6 +16,10 @@ import re
 
 import common
 
+# Import with_su
+with open('out/target/common/with_su', 'r') as withsuvariable:
+  with_su=withsuvariable.read().replace('\n', '')
+
 class EdifyGenerator(object):
   """Class to generate scripts in the 'edify' recovery script language
   used from donut onwards."""
@@ -173,10 +177,11 @@ class EdifyGenerator(object):
   def RunPersist(self, command):
     self.script.append(('run_program("/tmp/install/bin/persist.sh", "%s");' % command))
 
-  def FlashMagisk(self):
-    self.script.append('package_extract_dir("magisk", "/tmp/magisk");')
-    self.script.append('run_program("/sbin/busybox", "unzip", "/tmp/magisk/magisk.zip", "META-INF/com/google/android/*", "-d", "/tmp/magisk");')
-    self.script.append('run_program("/sbin/sh", "/tmp/magisk/META-INF/com/google/android/update-binary", "dummy", "1", "/tmp/magisk/magisk.zip");')
+  if with_su == "false":
+    def FlashMagisk(self):
+      self.script.append('package_extract_dir("magisk", "/tmp/magisk");')
+      self.script.append('run_program("/sbin/busybox", "unzip", "/tmp/magisk/magisk.zip", "META-INF/com/google/android/*", "-d", "/tmp/magisk");')
+      self.script.append('run_program("/sbin/sh", "/tmp/magisk/META-INF/com/google/android/update-binary", "dummy", "1", "/tmp/magisk/magisk.zip");')
 
   def ShowProgress(self, frac, dur):
     """Update the progress bar, advancing it over 'frac' over the next

--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -149,6 +149,10 @@ import common
 import edify_generator
 import sparse_img
 
+# Import with_su
+with open('out/target/common/with_su', 'r') as withsuvariable:
+  with_su=withsuvariable.read().replace('\n', '')
+
 OPTIONS = common.OPTIONS
 OPTIONS.package_key = None
 OPTIONS.incremental_source = None
@@ -789,14 +793,15 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   script.ShowProgress(0.05, 5)
   script.WriteRawImage("/boot", "boot.img")
 
-  if block_based:
-    script.Print(" ")
-    script.Print("Flashing Magisk...")
-    script.Print(" ")
-    common.ZipWriteStr(output_zip, "magisk/magisk.zip",
-                   ""+input_zip.read("SYSTEM/addon.d/magisk.zip"))
-    script.FlashMagisk()
-    script.Print(" ")
+  if with_su == "false":
+    if block_based:
+      script.Print(" ")
+      script.Print("Flashing Magisk...")
+      script.Print(" ")
+      common.ZipWriteStr(output_zip, "magisk/magisk.zip",
+                     ""+input_zip.read("SYSTEM/addon.d/magisk.zip"))
+      script.FlashMagisk()
+      script.Print(" ")
   script.ShowProgress(0.2, 10)
   device_specific.FullOTA_InstallEnd()
 


### PR DESCRIPTION
Currently Magisk is the default SU solution and no other SU solution can be selected. Thanks to this commit and my commit in android_vendor_beanstalk USE_SU := true in the device.mk can disable Magisk and enable the LineageSU solution some people prefer. This way Magisk stays the default SU solution and will only be replaced if USE_SU will be set to true.